### PR TITLE
fix(api): cache null soundcloud artwork responses correctly

### DIFF
--- a/src/app/api/soundcloud-artwork/route.test.ts
+++ b/src/app/api/soundcloud-artwork/route.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+type CacheVal = { ts: number; val: string | null };
+type CacheGlobal = typeof globalThis & { __scArtCache?: Map<string, CacheVal> };
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+function clearRouteCache() {
+  (globalThis as CacheGlobal).__scArtCache?.clear();
+}
+
+describe("GET /api/soundcloud-artwork", () => {
+  beforeEach(() => {
+    clearRouteCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearRouteCache();
+  });
+
+  it("returns 400 for invalid track urls and skips upstream fetch", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 500 }));
+
+    const res = await GET(
+      new Request(
+        "https://example.com/api/soundcloud-artwork?url=https://example.com/not-soundcloud",
+      ),
+    );
+    const json = (await res.json()) as { artwork: string | null };
+
+    expect(res.status).toBe(400);
+    expect(json).toEqual({ artwork: null });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("caches negative (null) upstream results within TTL", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 404 }));
+    const req = new Request(
+      "https://example.com/api/soundcloud-artwork?url=https://soundcloud.com/artist/mix",
+    );
+
+    const first = await GET(req);
+    const firstJson = (await first.json()) as { artwork: string | null };
+    const second = await GET(req);
+    const secondJson = (await second.json()) as { artwork: string | null };
+
+    expect(first.status).toBe(200);
+    expect(firstJson).toEqual({ artwork: null });
+    expect(second.status).toBe(200);
+    expect(secondJson).toEqual({ artwork: null });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches successful upstream artwork results within TTL", async () => {
+    const artwork = "https://i1.sndcdn.com/artworks-1234.jpg";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ thumbnail_url: artwork }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const req = new Request(
+      "https://example.com/api/soundcloud-artwork?url=https://soundcloud.com/artist/set",
+    );
+
+    const first = await GET(req);
+    const firstJson = (await first.json()) as { artwork: string | null };
+    const second = await GET(req);
+    const secondJson = (await second.json()) as { artwork: string | null };
+
+    expect(firstJson).toEqual({ artwork });
+    expect(secondJson).toEqual({ artwork });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after TTL expiry", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 404 }));
+    const req = new Request(
+      "https://example.com/api/soundcloud-artwork?url=https://soundcloud.com/artist/track",
+    );
+
+    await GET(req); // fetch #1
+
+    now += CACHE_TTL_MS - 1;
+    await GET(req); // cached hit
+
+    now += 2;
+    await GET(req); // fetch #2 after TTL
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/api/soundcloud-artwork/route.ts
+++ b/src/app/api/soundcloud-artwork/route.ts
@@ -2,18 +2,22 @@
 import { NextResponse } from "next/server";
 
 type CacheVal = { ts: number; val: string | null };
-const TTL = 10 * 60 * 1000;
+type CacheRead = { hit: false } | { hit: true; val: string | null };
+const CACHE_TTL_MS = 10 * 60 * 1000;
 
 declare global {
   var __scArtCache: Map<string, CacheVal> | undefined;
 }
 globalThis.__scArtCache = globalThis.__scArtCache ?? new Map<string, CacheVal>();
 
-function getCached(key: string) {
+function getCached(key: string): CacheRead {
   const hit = globalThis.__scArtCache!.get(key);
-  if (!hit) return null;
-  if (Date.now() - hit.ts > TTL) return null;
-  return hit.val;
+  if (!hit) return { hit: false } as const;
+  if (Date.now() - hit.ts > CACHE_TTL_MS) {
+    globalThis.__scArtCache!.delete(key);
+    return { hit: false } as const;
+  }
+  return { hit: true, val: hit.val } as const;
 }
 function setCached(key: string, val: string | null) {
   globalThis.__scArtCache!.set(key, { ts: Date.now(), val });
@@ -30,8 +34,8 @@ export async function GET(req: Request) {
 
     const key = trackUrl;
     const cached = getCached(key);
-    if (cached !== null) {
-      return NextResponse.json({ artwork: cached }, { headers: { "Cache-Control": "no-store" } });
+    if (cached.hit) {
+      return NextResponse.json({ artwork: cached.val }, { headers: { "Cache-Control": "no-store" } });
     }
 
     const res = await fetch(


### PR DESCRIPTION
## Summary
- replace nullable cache sentinel with explicit hit/miss contract
- keep TTL behavior and API response shape unchanged
- add route-level tests for miss/hit/null-hit and TTL-expiry behavior

## Validation
- 
pm test
- 
pm run lint (existing warning in src/app/page.tsx remains)
- 
pm run build

Closes #15