### PR TITLE
Fix command bar styling regressions (issue #16)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -135,4 +135,20 @@ video {
   .hover-lift {
     @apply transition-transform ease-out duration-150 hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:hover:translate-y-0;
   }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center rounded-md border border-white/20 bg-white/10 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-white transition-colors duration-150;
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    @apply border-white/35 bg-white/20;
+  }
+
+  .btn-secondary:focus-visible {
+    @apply outline-none ring-2 ring-white/70 ring-offset-2 ring-offset-black;
+  }
+
+  .btn-secondary:disabled {
+    @apply cursor-not-allowed opacity-40;
+  }
 }

--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -58,7 +58,7 @@ export default function CommandBar({ rows, onNavigate }: { rows: Row[]; onNaviga
           onClick={() => setOpen(false)}
         >
           <motion.div
-            className="mx-auto mt-24 w-[92vw] max-w-2xl rounded-2xl border border-white/10 bg-[var(--ash)]/60 backdrop-blur-xl overflow-hidden"
+            className="mx-auto mt-24 w-[92vw] max-w-2xl rounded-2xl border border-white/10 bg-black/75 backdrop-blur-xl overflow-hidden"
             initial={{ y: 10, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: 10, opacity: 0 }}


### PR DESCRIPTION
## Summary
- replace undefined \\ar(--ash)\\ token usage in Command Bar overlay
- add a concrete \\.btn-secondary\\ utility style used by Command Bar / Now Playing controls
- keep button focus-visible treatment explicit for keyboard accessibility

## Validation
- npm run lint
- npm run build

Closes #16