### PR TITLE
Docs + lint cleanup for README and page warning (issue #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,64 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# The Groove Archive
 
-## Getting Started
+Curated DJ set discovery app built with Next.js App Router and Supabase-backed data.
 
-First, run the development server:
+## Stack
+
+- Next.js 15 (App Router)
+- React 19
+- Tailwind CSS 4
+- Supabase (`@supabase/supabase-js`)
+- Vitest (unit tests)
+
+## Environment Variables
+
+Create a `.env` file in the project root:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+These are required by `src/lib/supabase.ts`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Local Development
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm install
+npm run dev
+```
 
-## Learn More
+App runs on `http://localhost:3000`.
 
-To learn more about Next.js, take a look at the following resources:
+## Scripts
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- `npm run dev`: start local dev server
+- `npm run lint`: run ESLint
+- `npm run test`: run Vitest test suite
+- `npm run build`: production build
+- `npm run start`: run production server
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Main Routes
 
-## Deploy on Vercel
+- `/`: hero + random "serve a set" flow
+- `/list`: full set list experience
+- `/artists`: artist view grouped by rating
+- `/heatmaps`: festival heatmap page with CSV upload/export
+- `/suggest`: suggestion form page
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## API Routes
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `GET /api/sheets?tabs=list,genres,artists`
+  - returns Supabase-backed data payload for selected tabs
+- `GET /api/soundcloud-artwork?url=<soundcloud-track-url>`
+  - returns SoundCloud artwork via oEmbed with in-memory cache
+
+## Data Notes
+
+- Server-side data fetches are in `src/lib/sheets.server.ts`.
+- Root layout loads shared site data once and passes it via `AppShell`/context.
+- Supabase tables expected by current code:
+  - `sets`
+  - `genres`
+  - `artists`
+  - `festival_sets`

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -696,7 +696,8 @@ ServeLaunchEffect.displayName = 'ServeLaunchEffect';
 const LaserHeads = React.forwardRef<
   LaserHeadsHandle,
   { containerRef: React.RefObject<HTMLElement | null>; className?: string }
->(({ containerRef: _containerRef, className }, ref) => {
+>((props, ref) => {
+  const { className } = props;
   const [heads, setHeads] = React.useState<HeadState[]>(() => [
     { angle: 42, hue: 210, length: 260, width: 14, pulse: 0 },
     { angle: -42, hue: 320, length: 260, width: 14, pulse: 0 },


### PR DESCRIPTION
## Summary
- replace template README with project-specific setup, env vars, routes, and API notes
- resolve unused \\_containerRef\\ warning in \\src/app/page.tsx\\`n
## Validation
- npm run lint (no warnings/errors)
- npm run build

Closes #19