### PR TITLE
[codex] Add approval-friendly verification scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Preferred Commands
+
+- Prefer `npm run ci:local` for a full CI-style local verification pass.
+- Prefer `npm run visual:smoke` for targeted homepage and heatmaps browser checks.
+- Prefer `npm run e2e:ci` when you need the full Playwright suite with CI-style placeholder envs.
+- Avoid inline PowerShell env wrappers when a package script already exists.
+
+## Git Workflow
+
+- Prefer short-lived `codex/*` branches for implementation work.
+- Do not merge without explicit user approval.
+- Do not stage or commit screenshots, temporary browser captures, or other local debug artifacts unless explicitly asked.
+
+## Visual Checks
+
+- Prefer the stable npm scripts over ad hoc browser shell commands.
+- Clean up temporary screenshot files after visual checks when they are not user-requested deliverables.
+
+## Repo Notes
+
+- This repo is often used on Windows, where sandboxed Next/Vitest/Playwright runs may hit `spawn EPERM`.
+- When that happens, prefer the stable npm scripts first, then request escalation only when needed.
+- CI-style placeholder Supabase envs intentionally disable live Supabase reads; the Playwright fixture path is the expected verification route for CI-style browser checks.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,19 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 - `npm run lint`: run ESLint across app code and `scripts/**`
 - `npm run typecheck`: run TypeScript in no-emit mode
 - `npm run check`: fast local sanity pass (`lint` + `typecheck`)
+- `npm run ci:local`: local CI-style verification (`check`, coverage, CI-style build, Playwright browser install, full E2E)
 - `npm run test`: run Vitest
 - `npm run test:coverage`: run Vitest with coverage thresholds
 - `npm run test:e2e`: run Playwright
+- `npm run e2e:ci`: run Playwright with the CI-style placeholder Supabase envs
 - `npm run test:e2e:headed`: run Playwright in headed mode
+- `npm run visual:smoke`: run the targeted homepage + heatmaps browser checks with the CI-style placeholder Supabase envs
 - `npm run logs:supabase -- <path-to-log.json>`: summarize a Supabase edge log event
 - `npm run build`: create a production build
+- `npm run build:ci`: create a production build with the CI-style placeholder Supabase envs
 - `npm run start`: start the production server
+
+The `*:ci`, `ci:local`, and `visual:smoke` commands are verification-focused commands. They use placeholder Supabase env values on purpose, which disables live Supabase reads and relies on the fixture-backed Playwright path already built into the repo. Use the regular scripts for normal live-data development.
 
 ## Fonts
 
@@ -98,3 +104,8 @@ The report includes request metadata, a `riskLevel`/`riskScore`, bot heuristics,
   - `genres`
   - `artists`
   - `festival_sets`
+
+## Agent Workflow
+
+- Repo-specific agent instructions live in [AGENTS.md](/C:/Users/joost/Documents/Repos/website-tga/AGENTS.md).
+- The main goal of those instructions is to keep verification and browser checks on stable npm scripts so repeated approval prompts are minimized.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitest/coverage-v8": "^4.0.18",
+        "cross-env": "^10.1.0",
         "eslint": "^9.39.3",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4.2.1",
@@ -372,6 +373,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -4034,6 +4042,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,18 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "build:ci": "cross-env NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=ci-placeholder-anon-key next build",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json",
     "check": "npm run lint && npm run typecheck",
+    "ci:local": "npm run check && npm run test:coverage && npm run build:ci && npx playwright install --with-deps chromium && npm run e2e:ci",
     "test": "vitest run",
+    "e2e:ci": "cross-env NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=ci-placeholder-anon-key playwright test",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:coverage": "vitest run --coverage",
+    "visual:smoke": "cross-env NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=ci-placeholder-anon-key playwright test e2e/home-record-bin.spec.ts e2e/site-smoke.spec.ts",
     "logs:supabase": "node scripts/analyze-supabase-log.mjs"
   },
   "dependencies": {
@@ -36,6 +40,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.0.18",
+    "cross-env": "^10.1.0",
     "eslint": "^9.39.3",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4.2.1",

--- a/src/components/record-bin/RecordBinExperience.tsx
+++ b/src/components/record-bin/RecordBinExperience.tsx
@@ -2,7 +2,7 @@
 
 import { motion, type PanInfo, useReducedMotion } from 'framer-motion';
 import Image from 'next/image';
-import { startTransition, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { startTransition, useEffect, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { SCIcon, YouTubeIcon } from '@/components/icons';
 import {
@@ -154,8 +154,8 @@ export function RecordBinExperience({
   selectorClassName = '',
 }: RecordBinExperienceProps) {
   const prefersReducedMotion = useReducedMotion();
-  const titleId = useId();
-  const statusId = useId();
+  const titleId = title ? 'record-bin-title' : undefined;
+  const statusId = 'record-bin-status';
   const binRef = useRef<HTMLDivElement>(null);
   const activeCardRef = useRef<HTMLButtonElement | null>(null);
   const activeCardFrameRef = useRef<HTMLElement | null>(null);


### PR DESCRIPTION
## Summary
- add stable CI-style npm scripts using cross-env so verification no longer depends on inline PowerShell env wrappers
- add a repo-root AGENTS.md with Codex workflow guidance for scripts, Git, visual checks, and Windows sandbox quirks
- make record-bin IDs deterministic so the new one-command local CI flow stays green without labs hydration warnings

## Validation
- npm run check
- npm run build:ci
- npm run visual:smoke
- npm run e2e:ci
- npm run ci:local